### PR TITLE
use domain key from process if available

### DIFF
--- a/src/operations/tools/rum-bundles.js
+++ b/src/operations/tools/rum-bundles.js
@@ -103,7 +103,7 @@ const rumDataTool = {
     const startDateFinal = startdate?.trim() || start;
     const endDateFinal = enddate?.trim() || end;
 
-    const result = await getAllBundles(domain, domainkey, startDateFinal, endDateFinal, aggregation);
+    const result = await getAllBundles(domain, domainkey || process.env.RUM_DOMAIN_KEY, startDateFinal, endDateFinal, aggregation);
     
     // Include date range in the response
     return wrapToolJSONResult({


### PR DESCRIPTION
small one, use domain key from process env if it's there. The readme mentions this process env, but code didn't seem to use it before. this should fix that.